### PR TITLE
Correction de la mise en VIP du serveur

### DIFF
--- a/src/main/java/net/bridgesapis/bungeebridge/core/proxies/BridgeListener.java
+++ b/src/main/java/net/bridgesapis/bungeebridge/core/proxies/BridgeListener.java
@@ -132,7 +132,7 @@ public class BridgeListener implements Listener {
 				}
 			}
 
-			if (instance.getType().equals(ServerSettings.CloseType.CLOSED)) {
+			if (instance.getType().equals(ServerSettings.CloseType.VIP)) {
 				if (! user.hasPermission("netjoin.closed") || ! user.hasPermission("netjoin.vip")) {
 					e.setCancelled(true);
 					e.setCancelReason(I18n.getTranslation("serverstate.reserved_to_permission"));


### PR DESCRIPTION
Correction de la vérification lors de la connexion d'un joueur. Actuellement, si le serveur est en VIP,  tout le monde peut rejoindre le serveur.
